### PR TITLE
おまけ：Github Actionsの修正

### DIFF
--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -24,6 +24,8 @@ jobs:
   create-issue-labels:
     needs: get-issue-labels
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       matrix: 
         label: ${{ fromJson(needs.get-issue-labels.outputs.labels) }}
@@ -59,6 +61,8 @@ jobs:
   create-milestones:
     needs: get-milestones
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       matrix: 
         milestone: ${{ fromJson(needs.get-milestones.outputs.milestones) }}
@@ -135,6 +139,8 @@ jobs:
   create-issues:
     needs: [create-issue-labels, get-myrepo-milestones, get-issues, get-myrepo-issues]
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     strategy:
       max-parallel: 1
       matrix: 

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -113,7 +113,7 @@ jobs:
     - id: output_issues_data
       # milestoneが設定されているissueのみに絞る
       run: |
-        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq '[.[] | select(has("milestone"))]')
+        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq -c '[.[] | select(has("milestone"))]')
         echo "value=${result}" >> $GITHUB_OUTPUT
     - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -93,7 +93,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - id: output_milestones_data
       run: |
-        result=$(echo '${{ steps.get_milestones_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
+        result=$(echo '${{ steps.get_milestones_data.outputs.data }}')
         echo "value=${result}" >> $GITHUB_OUTPUT
   get-issues:
     if: github.repository != 'yumemi-inc/android-engineer-codecheck'
@@ -134,7 +134,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - id: output_issues_data
       run: |
-        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
+        result=$(echo '${{ steps.get_issues_data.outputs.data }}')
         echo "value=${result}" >> $GITHUB_OUTPUT
     - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -113,9 +113,9 @@ jobs:
     - id: output_issues_data
       # milestoneが設定されているissueのみに絞る
       run: |
-        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq -c '[.[] | select(has("milestone"))]')
+        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq -c '[.[] | select(has("milestone")) | select(.milestone != null)]')
         echo "value=${result}" >> $GITHUB_OUTPUT
-    - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
+    - run: echo '${{ steps.output_issues_data.outputs.value }} | jq'
 
   get-myrepo-issues:
     if: github.repository != 'yumemi-inc/android-engineer-codecheck'

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -31,6 +31,7 @@ jobs:
         label: ${{ fromJson(needs.get-issue-labels.outputs.labels) }}
     steps:
     - name: Create a label
+      if: false
       uses: octokit/request-action@v2.1.7
       with:
         route: POST /repos/${{ github.repository }}/labels
@@ -68,6 +69,7 @@ jobs:
         milestone: ${{ fromJson(needs.get-milestones.outputs.milestones) }}
     steps:
     - name: Create a milestone
+      if: false
       uses: octokit/request-action@v2.1.7
       with:
         route: POST /repos/${{ github.repository }}/milestones

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -105,8 +105,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - id: output_issues_data
+      # milestoneが設定されているissueのみに絞る
       run: |
-        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
+        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq '[.[] | select(has("milestone"))]' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
         echo "{value}={result}" >> $GITHUB_OUTPUT
     - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 
@@ -146,14 +147,15 @@ jobs:
         milestone_number=$(echo ${milestones} | jq '.[] | select (.title=="${{ matrix.issue.milestone.title }}") | .number' )
         echo "::set-output name=number::${milestone_number}"
     - name: Create a issue
-      if: ${{ matrix.issue.pull_request == null }}
+      # issue検索時にフィルタリングしているためここでのフィルタリングは不要になる。また、テスト用に一時的に出力を切っておく
+      if: false
       run: |
         body=$(echo '${{ matrix.issue.body }}')
         body="${body//$'\n'/\\n}"
         body="${body//$'\r'/\\r}"
         
         if [[ "$body" =~ '#'[0-9] ]]; then
-            link=$(echo "$body" | grep -o "#[0-9]")
+            link=$(echo "$body" | grep -o "#[0-9]+")
             num=$(echo $link | tr -d '#')
 
             issues=$(echo '${{ needs.get-issues.outputs.issues }}' | jq '[ . as $d | keys[] | $d[.] + {index:.} ]')
@@ -174,3 +176,5 @@ jobs:
             \"labels\" : ${labels},
             \"milestone\" : ${{ steps.find-milestone.outputs.number }}
           }"
+    - name: Print issue for debug
+      run: echo '${{ matrix.issue.body }}'

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -113,7 +113,7 @@ jobs:
     - id: output_issues_data
       # milestoneが設定されているissueのみに絞る
       run: |
-        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq '[.[] | select(has("milestone"))]' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
+        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq '[.[] | select(has("milestone"))]')
         echo "value=${result}" >> $GITHUB_OUTPUT
     - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -133,7 +133,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - id: output_issues_data
       run: |
-        result=$(echo '${{ steps.get_issues_data.outputs.data }}')
+        result=$(echo '${{ steps.get_issues_data.outputs.data }}' | sed -z 's/\n//g')
         echo "value=${result}" >> $GITHUB_OUTPUT
 
   create-issues:

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -19,7 +19,7 @@ jobs:
     - id: output_label_data
       run: |
         result=$(echo '${{ steps.get_label_data.outputs.data }}' | sed -z 's/\n//g')
-        echo "::set-output name=value::${result}"
+        echo "{value}={result}" >> $GITHUB_OUTPUT
 
   create-issue-labels:
     needs: get-issue-labels
@@ -54,7 +54,7 @@ jobs:
     - id: output_milestones_data
       run: |
         result=$(echo '${{ steps.get_milestones_data.outputs.data }}' | sed -z 's/\n//g')
-        echo "::set-output name=value::${result}"
+        echo "{value}={result}" >> $GITHUB_OUTPUT
 
   create-milestones:
     needs: get-milestones
@@ -88,8 +88,7 @@ jobs:
     - id: output_milestones_data
       run: |
         result=$(echo '${{ steps.get_milestones_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
-        echo "::set-output name=value::${result}"
-
+        echo "{value}={result}" >> $GITHUB_OUTPUT
   get-issues:
     if: github.repository != 'yumemi-inc/android-engineer-codecheck'
     runs-on: ubuntu-latest
@@ -108,7 +107,7 @@ jobs:
     - id: output_issues_data
       run: |
         result=$(echo '${{ steps.get_issues_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
-        echo "::set-output name=value::${result}"
+        echo "{value}={result}" >> $GITHUB_OUTPUT
     - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 
   get-myrepo-issues:
@@ -129,7 +128,7 @@ jobs:
     - id: output_issues_data
       run: |
         result=$(echo '${{ steps.get_issues_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
-        echo "::set-output name=value::${result}"
+        echo "{value}={result}" >> $GITHUB_OUTPUT
     - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 
   create-issues:

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -19,7 +19,7 @@ jobs:
     - id: output_label_data
       run: |
         result=$(echo '${{ steps.get_label_data.outputs.data }}' | sed -z 's/\n//g')
-        echo "{value}={result}" >> $GITHUB_OUTPUT
+        echo "value=${result}" >> $GITHUB_OUTPUT
 
   create-issue-labels:
     needs: get-issue-labels
@@ -56,7 +56,7 @@ jobs:
     - id: output_milestones_data
       run: |
         result=$(echo '${{ steps.get_milestones_data.outputs.data }}' | sed -z 's/\n//g')
-        echo "{value}={result}" >> $GITHUB_OUTPUT
+        echo "value=${result}" >> $GITHUB_OUTPUT
 
   create-milestones:
     needs: get-milestones
@@ -92,7 +92,7 @@ jobs:
     - id: output_milestones_data
       run: |
         result=$(echo '${{ steps.get_milestones_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
-        echo "{value}={result}" >> $GITHUB_OUTPUT
+        echo "value=${result}" >> $GITHUB_OUTPUT
   get-issues:
     if: github.repository != 'yumemi-inc/android-engineer-codecheck'
     runs-on: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
       # milestoneが設定されているissueのみに絞る
       run: |
         result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq '[.[] | select(has("milestone"))]' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
-        echo "{value}={result}" >> $GITHUB_OUTPUT
+        echo "value=${result}" >> $GITHUB_OUTPUT
     - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 
   get-myrepo-issues:
@@ -133,7 +133,7 @@ jobs:
     - id: output_issues_data
       run: |
         result=$(echo '${{ steps.get_issues_data.outputs.data }}' | sed -z 's/\n/%0A/g' | sed -z 's/\r/%0D/g')
-        echo "{value}={result}" >> $GITHUB_OUTPUT
+        echo "value=${result}" >> $GITHUB_OUTPUT
     - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 
   create-issues:
@@ -151,7 +151,7 @@ jobs:
       run: |
         milestones='${{ needs.get-myrepo-milestones.outputs.milestones }}'
         milestone_number=$(echo ${milestones} | jq '.[] | select (.title=="${{ matrix.issue.milestone.title }}") | .number' )
-        echo "::set-output name=number::${milestone_number}"
+        echo "number=${milestone_number}" >> $GITHUB_OUTPUT
     - name: Create a issue
       # issue検索時にフィルタリングしているためここでのフィルタリングは不要になる。また、テスト用に一時的に出力を切っておく
       if: false

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -111,7 +111,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - id: output_issues_data
-      # milestoneが設定されているissueのみに絞る
       run: |
         result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq -c '[.[] | select(has("milestone")) | select(.milestone != null)]')
         echo "value=${result}" >> $GITHUB_OUTPUT
@@ -153,8 +152,6 @@ jobs:
         milestone_number=$(echo ${milestones} | jq '.[] | select (.title=="${{ matrix.issue.milestone.title }}") | .number' )
         echo "number=${milestone_number}" >> $GITHUB_OUTPUT
     - name: Create a issue
-      # issue検索時にフィルタリングしているためここでのフィルタリングは不要になる。また、テスト用に一時的に出力を切っておく
-      if: false
       run: |
         body=$(echo '${{ matrix.issue.body }}')
         body="${body//$'\n'/\\n}"
@@ -182,5 +179,3 @@ jobs:
             \"labels\" : ${labels},
             \"milestone\" : ${{ steps.find-milestone.outputs.number }}
           }"
-    - name: Print issue for debug
-      run: echo '${{ matrix.issue.body }}'

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -93,7 +93,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - id: output_milestones_data
       run: |
-        result=$(echo '${{ steps.get_milestones_data.outputs.data }}')
+        result=$(echo '${{ steps.get_milestones_data.outputs.data }}' | sed -z 's/\n//g')
         echo "value=${result}" >> $GITHUB_OUTPUT
   get-issues:
     if: github.repository != 'yumemi-inc/android-engineer-codecheck'
@@ -115,7 +115,6 @@ jobs:
       run: |
         result=$(echo '${{ steps.get_issues_data.outputs.data }}' | jq -c '[.[] | select(has("milestone")) | select(.milestone != null)]')
         echo "value=${result}" >> $GITHUB_OUTPUT
-    - run: echo '${{ steps.output_issues_data.outputs.value }} | jq'
 
   get-myrepo-issues:
     if: github.repository != 'yumemi-inc/android-engineer-codecheck'
@@ -136,7 +135,6 @@ jobs:
       run: |
         result=$(echo '${{ steps.get_issues_data.outputs.data }}')
         echo "value=${result}" >> $GITHUB_OUTPUT
-    - run: echo -e '${{ steps.output_issues_data.outputs.value }}'
 
   create-issues:
     needs: [create-issue-labels, get-myrepo-milestones, get-issues, get-myrepo-issues]

--- a/.github/workflows/copy-issues.yml
+++ b/.github/workflows/copy-issues.yml
@@ -31,7 +31,6 @@ jobs:
         label: ${{ fromJson(needs.get-issue-labels.outputs.labels) }}
     steps:
     - name: Create a label
-      if: false
       uses: octokit/request-action@v2.1.7
       with:
         route: POST /repos/${{ github.repository }}/labels
@@ -69,7 +68,6 @@ jobs:
         milestone: ${{ fromJson(needs.get-milestones.outputs.milestones) }}
     steps:
     - name: Create a milestone
-      if: false
       uses: octokit/request-action@v2.1.7
       with:
         route: POST /repos/${{ github.repository }}/milestones


### PR DESCRIPTION
課題開始時に問題が出た、GIthub Actionsの修正を行う。
Issueに出してからの修正点は次の通り

- パーミッションの追加（これは他者のプルリクエストから引用しているので、もともとのプルリクエストからは取り除きます）
- アウトプットの方式の変更
  - 改行絡みのエラーを吐いていること、データの確認方法に一貫性がないことから改行を削除
- Issueの取り方の変更
  - 「マイルストーンが紐づいている」Issueを指定すれば変更があっても過不足なく取れると思われる
- 「Create a issue」のバグ修正
  - Issueの番号の抽出方法が1桁しか見ていなかったことから、今後Issueを変更したときに参照先の抽出がうまくいかない可能性が高い